### PR TITLE
Remove incorrectly required 'url' field from 'Subscription' for f3411-19

### DIFF
--- a/remoteid/augmented.yaml
+++ b/remoteid/augmented.yaml
@@ -1549,7 +1549,6 @@ components:
         in on an ongoing basis (e.g., “planning area”).  Internal to the DSS.
       required:
       - id
-      - url
       - notification_index
       - owner
       - version


### PR DESCRIPTION
The standard seems to require a non-obligatory field in the `Subscription` object.

This causes failures in the validations done by the `uss_qualifier` (in https://github.com/interuss/monitoring/) when we rely on this OpenAPI spec.

As discussed with @BenjaminPelletier, this requirement should be dropped.

Using the updated version of `remoteid/augmented.yaml` (on the branch f3411-19) the relevant OpenAPI validations work locally.